### PR TITLE
Adds missing parens

### DIFF
--- a/lib/readAllNotes.ts
+++ b/lib/readAllNotes.ts
@@ -46,7 +46,7 @@ export default async function readAllNotes(
     withFileTypes: true
   });
   const notePaths = noteDirectoryEntries
-    .filter(entry => entry.isFile() && !entry.name.startsWith("." && entry.name.endsWith(".md"))
+    .filter(entry => entry.isFile() && !entry.name.startsWith(".") && entry.name.endsWith(".md"))
     .map(entry => path.join(noteFolderPath, entry.name));
 
   const noteEntries = await Promise.all(


### PR DESCRIPTION
[A merged PR](https://github.com/andymatuschak/note-link-janitor/pull/4/files) introduced a bug as `!entry.name.startsWith("."` doesn't have closing parens.

This PR fixes that.




 