### PR TITLE
Backlink insertion is idempotent

### DIFF
--- a/lib/readAllNotes.ts
+++ b/lib/readAllNotes.ts
@@ -46,7 +46,7 @@ export default async function readAllNotes(
     withFileTypes: true
   });
   const notePaths = noteDirectoryEntries
-    .filter(entry => entry.isFile() && !entry.name.startsWith(".") && entry.name.endsWith(".md"))
+    .filter(entry => entry.isFile() && !entry.name.startsWith(".") && entry.name.endsWith(".md") && !entry.name.startsWith("_"))
     .map(entry => path.join(noteFolderPath, entry.name));
 
   const noteEntries = await Promise.all(

--- a/lib/updateBacklinks.ts
+++ b/lib/updateBacklinks.ts
@@ -82,13 +82,23 @@ export default function updateBacklinks(
             )
             .join("")}`
       )
-      .join("")}\n`;
+      .join("")}`.trim();
   }
 
-  const newNoteContents =
-    noteContents.slice(0, insertionOffset) +
-    backlinksString +
-    noteContents.slice(oldEndOffset);
+  let newNoteContents = noteContents;
+
+  if (backlinksString) {
+    let end = noteContents.slice(oldEndOffset).trim()
+
+    if (end) {
+      end = `\n${end}\n`;
+    }
+
+    newNoteContents =
+      noteContents.slice(0, insertionOffset).trimEnd() + "\n\n" +
+      backlinksString + "\n" +
+      end
+  }
 
   return newNoteContents;
 }

--- a/lib/updateBacklinks.ts
+++ b/lib/updateBacklinks.ts
@@ -78,7 +78,7 @@ export default function updateBacklinks(
         entry =>
           `* [[${entry.sourceTitle}]]\n${entry.context
             .map(
-              block => `\t* ${processor.stringify(block).replace(/\n.+/, "")}\n`
+              block => `  * ${processor.stringify(block).replace(/\n.+/, "")}\n`
             )
             .join("")}`
       )
@@ -88,16 +88,18 @@ export default function updateBacklinks(
   let newNoteContents = noteContents;
 
   if (backlinksString) {
-    let end = noteContents.slice(oldEndOffset).trim()
+    let end = noteContents.slice(oldEndOffset).trim();
 
     if (end) {
       end = `\n${end}\n`;
     }
 
     newNoteContents =
-      noteContents.slice(0, insertionOffset).trimEnd() + "\n\n" +
-      backlinksString + "\n" +
-      end
+      noteContents.slice(0, insertionOffset).trimEnd() +
+      "\n\n" +
+      backlinksString +
+      "\n" +
+      end;
   }
 
   return newNoteContents;


### PR DESCRIPTION
Prior to this, there was no newline between the text prior to the backlinks which caused it to not properly detect the backlink section.

This perhaps isn't the cleanest implementation, but it fixes things for me. It also gets rid of the extra newline at the end of files that was previously emitted. 