### PR TITLE
Add Backlinks above last comment block rather than first

### DIFF
--- a/lib/getBacklinksBlock.ts
+++ b/lib/getBacklinksBlock.ts
@@ -28,7 +28,7 @@ export default function getBacklinksBlock(
   );
   if (existingBacklinksNodeIndex === -1) {
     const insertionPoint =
-      tree.children.find(node => is(node, isClosingMatterNode)) || null;
+      tree.children.slice().reverse().find(node => is(node, isClosingMatterNode)) || null;
     return {
       isPresent: false,
       insertionPoint


### PR DESCRIPTION
Fixes the problem of adding the Backlinks section at the top of the file if tags are at the top. Example:

```# A file
<!-- #tag1 #tag2 -->

Some contents

<!-- {BearID: 123} -->
```

Currently output will be

```# A file
## Backlinks
* [[Another file]]
  * Referring to [[A file]]

<!-- #tag1 #tag2 -->

Some contents

<!-- {BearID: 123} -->
```

This finds the last comment instead of the first, making the output:

```# A file
<!-- #tag1 #tag2 -->

Some contents

## Backlinks
* [[Another file]]
  * Referring to [[A file]]

<!-- {BearID: 123} -->
```