### PR TITLE
Ensure consistent newline at end of content

### DIFF
--- a/lib/updateBacklinks.ts
+++ b/lib/updateBacklinks.ts
@@ -10,6 +10,10 @@ export interface BacklinkEntry {
   context: MDAST.BlockContent[];
 }
 
+function ensureSingleNewlineAtEnd(contents: string): string {
+  return contents.trimEnd() + "\n";
+}  
+
 export default function updateBacklinks(
   tree: MDAST.Root,
   noteContents: string,
@@ -73,7 +77,7 @@ export default function updateBacklinks(
         }
       ]
     };
-    backlinksString = `## Backlinks\n${backlinks
+    backlinksString = `\n## Backlinks\n${backlinks
       .map(
         entry =>
           `* [[${entry.sourceTitle}]]\n${entry.context
@@ -82,11 +86,11 @@ export default function updateBacklinks(
             )
             .join("")}`
       )
-      .join("")}\n`;
+      .join("")}`;
   }
 
   const newNoteContents =
-    noteContents.slice(0, insertionOffset) +
+    ensureSingleNewlineAtEnd(noteContents.slice(0, insertionOffset)) +
     backlinksString +
     noteContents.slice(oldEndOffset);
 


### PR DESCRIPTION
- Ensures all Markdown files end with a single \n character.
- Ensures there are two \n characters between content and backlinks.

After making this change, I just noticed that #9 does something similar. The current proposal seems to be a more straightforward to deal with Markdown files that do not (yet) consistently end with a single `\n`.