### PR TITLE
Fall back to Gollum page titling if headers not found

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ The backlinks section will be initially inserted at the end of the file. If ther
 ## Assumptions/warnings
 
 1. Links are formatted `[[like this]]`.
-2. Note titles are inferred from the first line of each note, which is assumed to be formatted as a heading, i.e. `# Note title`.
+2. Note titles are inferred from the first line of each note, which is assumed to be formatted as a heading, i.e. `# Note title`. If this heading is not available, the GitHub wiki / Gollum scheme is used: the file name serves as the title, with dashes (`-`) replaced by spaces.
 3. All `.md` files are siblings; the script does not currently recursively traverse subtrees (though that would be a simple modification if you need it; see `lib/readAllNotes.ts`)
 4. The backlinks "section" is defined as the AST span between `## Backlinks` and the next heading tag (or `<!-- -->` tag). Any text you might add to this section will be clobbered. Don't append text after the backlinks list without a heading in between! (I like to leave my backlinks list at the end of the file)
 

--- a/lib/readAllNotes.ts
+++ b/lib/readAllNotes.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as MDAST from "mdast";
 import * as path from "path";
 import * as remark from "remark";
+import { Node } from "unist";
 import * as find from "unist-util-find";
 
 import getNoteLinks, { NoteLinkEntry } from "./getNoteLinks";
@@ -19,6 +20,18 @@ interface Note {
   parseTree: MDAST.Root;
 }
 
+function fileNameWithoutExtension(path: string): string {
+  return path.split("/").slice(-1)[0].split(".")[0];
+}
+
+function withGollumPageNamingScheme(name: string): string {
+  return name.replace(/-/g, " ");
+}
+
+function servesAsPageHeader(headingNode: Node): boolean {
+  return headingNode.position?.start.line === 0;
+}
+
 async function readNote(notePath: string): Promise<Note> {
   const noteContents = await fs.promises.readFile(notePath, {
     encoding: "utf-8"
@@ -26,15 +39,17 @@ async function readNote(notePath: string): Promise<Note> {
 
   const parseTree = processor.parse(noteContents) as MDAST.Root;
   const headingNode = await headingFinder.run(parseTree);
-  if (headingNode.type === "missingTitle") {
-    throw new Error(`${notePath} has no title`);
+  let title: string;
+  if (headingNode.type === "missingTitle" || !servesAsPageHeader(headingNode)) {
+    title = withGollumPageNamingScheme(fileNameWithoutExtension(notePath));
+  } else {
+    title = remark()
+      .stringify({
+        type: "root",
+        children: (headingNode as MDAST.Heading).children
+      })
+      .trimEnd();
   }
-  const title = remark()
-    .stringify({
-      type: "root",
-      children: (headingNode as MDAST.Heading).children
-    })
-    .trimEnd();
 
   return { title, links: getNoteLinks(parseTree), parseTree, noteContents };
 }


### PR DESCRIPTION
Inspired by https://github.com/andymatuschak/note-link-janitor/commit/3d0876aaad3ed91784a23330992ccf3da4e6f7b0, the current change should enable working with [Gollum](https://github.com/gollum/gollum)-based wikis such as the GitHub built-in wiki feature, while keeping full compatibility with the `# Title`-based workflow.

Just posting this for reference in case others are looking for the same feature: as per the “FYI-style open source” note in README I don’t expect this to be merged.